### PR TITLE
Add csit-1-node-test Workflow

### DIFF
--- a/.github/workflows/csit-1-node.yaml
+++ b/.github/workflows/csit-1-node.yaml
@@ -1,0 +1,151 @@
+name: CSIT-1-Node-Test
+
+on:
+  push:
+
+jobs:
+  daexim-csit-1-node-argon:
+    runs-on: ubuntu-latest
+
+    services:
+      opendaylight:
+        image: ${{ vars.REPOSITORY }}/${{ vars.ODL_IMAGE }}
+        env:
+          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
+        ports:
+          - 8181:8181
+        options: --name odl-container
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: ssh
+        run: |
+          docker exec odl-container bash -c "mkdir /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
+      - name: Start robot container
+        run: |
+          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
+
+      - name: Extract id_rsa.pub from the robot container
+        id: extract_pubkey
+        run: |
+          docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
+        continue-on-error: true
+
+      - name: Add public key to opendaylight container
+        run: |
+          PUB_KEY=$(cat id_rsa.pub)
+          docker exec odl-container bash -c "mkdir /home/youruser/.shh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
+      - name: Delay for 30 seconds
+        run: sleep 30
+
+      - name: Run Test
+        run: |
+          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
+            cd integration-test/csit/suites/daexim && 
+            robot -L debug --variable USER_HOME:/root \
+            --variable WORKSPACE:/home/youruser \
+            -v BUNDLEFOLDER:karaf-0.18.1 \
+            -v ODL_STREAM:argon \
+            --variable DEFAULT_LINUX_PROMPT:\$ \
+            --variable ODL_SYSTEM_USER:youruser \
+            --variable ODL_SYSTEM_IP:opendaylight \
+            --variable ODL_SYSTEM_1_IP:opendaylight \
+            -v IS_KARAF_APPL:True \
+            ./010-special-export.robot 020-import-basic.robot 030-export-basic.robot 040-export-inclusions.robot '
+
+  aaa-csit-1-node-authn-all-argon:
+    runs-on: ubuntu-latest
+
+    services:
+      opendaylight:
+        image: ayushishu/odl:v1
+        env:
+          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
+        ports:
+          - 8181:8181
+        options: --name odl-container
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup-jolokia
+        run: |
+          docker exec -i odl-container bash -c \
+            'echo "org.jolokia.authMode=basic" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+             echo "org.jolokia.user=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg && \
+             echo "org.jolokia.password=admin" >> /home/youruser/karaf-0.18.1/etc/org.jolokia.osgi.cfg'
+      - name: Start robot container
+        run: |
+          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
+
+      - name: Delay for 30 seconds
+        run: sleep 30
+
+      - name: Run Test
+        run: |
+          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
+            cd integration-test/csit/suites/aaa && 
+            robot -L debug --variable USER_HOME:/root \
+            --variable WORKSPACE:/home/youruser \
+            -v BUNDLEFOLDER:karaf-0.18.1 \
+            -v ODL_STREAM:argon \
+            --variable DEFAULT_LINUX_PROMPT:\$ \
+            --variable ODL_SYSTEM_USER:youruser \
+            --variable ODL_SYSTEM_IP:opendaylight \
+            --variable ODL_SYSTEM_1_IP:opendaylight \
+            -v IS_KARAF_APPL:True \
+            ./authn '
+
+  distribution-csit-1-node-userfeatures-all:
+    runs-on: ubuntu-latest
+
+    services:
+      opendaylight:
+        image: ayushishu/odl:v1
+        env:
+          FEATURES: odl-restconf,odl-daexim-all,odl-netconf-topology,odl-jolokia
+        ports:
+          - 8181:8181
+        options: --name odl-container
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: ssh
+        run: |
+          docker exec odl-container bash -c "mkdir /home/youruser/.ssh && touch /home/youruser/.ssh/authorized_keys"
+      - name: Start robot container
+        run: |
+          docker run -d --network container:odl-container --name robot ${{ vars.REPOSITORY }}/${{ vars.ROBOT_IMAGE }} tail -f /dev/null
+
+      - name: Extract id_rsa.pub from the robot container
+        id: extract_pubkey
+        run: |
+          docker exec robot cat /root/.ssh/id_rsa.pub > id_rsa.pub
+        continue-on-error: true
+
+      - name: Add public key to opendaylight container
+        run: |
+          PUB_KEY=$(cat id_rsa.pub)
+          docker exec odl-container bash -c "mkdir /home/youruser/.shh && echo \"$PUB_KEY\" >> /home/youruser/.ssh/authorized_keys"
+      - name: Delay for 30 seconds
+        run: sleep 30
+
+      - name: Run Test
+        run: |
+          docker exec robot bash -c 'git clone https://github.com/opendaylight/integration-test.git &&       
+            cd integration-test/csit/suites/distribution && 
+            robot -L debug --variable USER_HOME:/root \
+            --variable WORKSPACE:/home/youruser \
+            -v BUNDLEFOLDER:karaf-0.18.1 \
+            -v ODL_STREAM:argon \
+            --variable DEFAULT_LINUX_PROMPT:\$ \
+            --variable ODL_SYSTEM_USER:youruser \
+            --variable ODL_SYSTEM_IP:opendaylight \
+            --variable ODL_SYSTEM_1_IP:opendaylight \
+            -v IS_KARAF_APPL:True \
+            ./karaf_sequence_install.robot karaf_stop.robot size.robot'


### PR DESCRIPTION
This commit adds GitHub Actions workflows for running CSIT (Continuous System Integration Test) 1-Node tests on an OpenDaylight instance. Three separate workflows are included:

1. daexim-csit-1-node:
   - Sets up an OpenDaylight container with specific features.
   - Configures SSH and public key authentication.
   - Runs daexim-specific CSIT tests.

2. aaa-csit-1-node-authn-all:
   - Sets up an OpenDaylight container with specific features and Jolokia configuration.
   - Runs AAA (Authentication, Authorization, and Accounting) specific CSIT tests.

3. distribution-csit-1-node-userfeatures-all:
   - Sets up an OpenDaylight container with specific features.
   - Configures SSH and public key authentication.
   - Runs distribution-specific CSIT tests.
